### PR TITLE
제너릭 타입 수정

### DIFF
--- a/src/components/ability-container/index.tsx
+++ b/src/components/ability-container/index.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, ReactElement, useMemo } from "react";
+import React, { ReactElement, useMemo } from "react";
 import {
   DoubleListContainer,
   ListItem,
@@ -28,7 +28,7 @@ const AbilityContainer = ({
   userData,
   subNav,
   setDialog,
-}: PropsWithChildren<IAbilityContainer<IUserData>>) => {
+}: IAbilityContainer<IUserData>) => {
   const {
     characteristicInfo,
     equipInfo: { equipment, avatar, badge, gem },

--- a/src/components/async-boundary/index.tsx
+++ b/src/components/async-boundary/index.tsx
@@ -10,7 +10,6 @@ import { ErrorBoundary } from "components/";
 interface IAsyncBoundary {
   suspenseFallback: ReactNode;
   errorFallback: ReactElement;
-  children: ReactElement;
   keys?: any;
 }
 

--- a/src/components/basic-info/index.tsx
+++ b/src/components/basic-info/index.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from "react";
+import React from "react";
 import { Image, Text } from "../";
 import * as Styled from "./index.styles";
 
@@ -11,9 +11,7 @@ interface IBasicInfo<T> {
   userData: T;
 }
 
-const BasicInfo = <T extends IUserData>({
-  userData,
-}: PropsWithChildren<IBasicInfo<T>>) => {
+const BasicInfo = <T extends IUserData>({ userData }: IBasicInfo<T>) => {
   const { basicInfo, expeditionInfo } = userData;
   const {
     className,

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -1,13 +1,7 @@
-import React, {
-  ButtonHTMLAttributes,
-  PropsWithChildren,
-  ReactNode,
-} from "react";
+import React, { ButtonHTMLAttributes, PropsWithChildren } from "react";
 import * as Styled from "./index.style";
 
-export interface IButton extends ButtonHTMLAttributes<HTMLButtonElement> {
-  children: ReactNode;
-}
+export interface IButton extends ButtonHTMLAttributes<HTMLButtonElement> {}
 
 const Button = ({ children, ...props }: PropsWithChildren<IButton>) => (
   <Styled.Button {...props}>{children}</Styled.Button>

--- a/src/components/characteristic/index.tsx
+++ b/src/components/characteristic/index.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from "react";
+import React from "react";
 import { DangerousHTML, Text, MapContainer } from "../";
 import * as Styled from "./index.style";
 
@@ -16,9 +16,7 @@ interface ICharacteristic<T> {
   data?: T;
 }
 
-const Chararteristic = <T extends IData>({
-  data,
-}: PropsWithChildren<ICharacteristic<T>>) => {
+const Chararteristic = <T extends IData>({ data }: ICharacteristic<T>) => {
   return (
     <Styled.Container key={data.title}>
       <Styled.Title>
@@ -35,7 +33,7 @@ interface IItem<T> {
   data?: T;
 }
 
-const Item = <T extends IContent>({ data }: PropsWithChildren<IItem<T>>) => {
+const Item = <T extends IContent>({ data }: IItem<T>) => {
   return (
     <Styled.Item key={data.title[0]}>
       <Styled.Title type="itemTitle">

--- a/src/components/collection/index.tsx
+++ b/src/components/collection/index.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from "react";
+import React from "react";
 import { DoubleListContainer } from "components/";
 import ListItem from "components/list-item";
 
@@ -11,7 +11,7 @@ interface ICollection {
   };
 }
 
-const Collection = ({ data, mini }: PropsWithChildren<ICollection>) => {
+const Collection = ({ data, mini }: ICollection) => {
   const lt = mini.title;
   const rt = `획득 : ${mini.getCount} 총 : ${mini.totalCount}`;
   return (

--- a/src/components/dangerous-html/index.tsx
+++ b/src/components/dangerous-html/index.tsx
@@ -1,11 +1,11 @@
-import React, { PropsWithChildren } from "react";
+import React from "react";
 import * as Styled from "./index.style";
 
 interface IDangerousHTML {
   html?: string;
 }
 
-const DangerousHTML = ({ html }: PropsWithChildren<IDangerousHTML>) => {
+const DangerousHTML = ({ html }: IDangerousHTML) => {
   return <Styled.Container dangerouslySetInnerHTML={{ __html: html }} />;
 };
 

--- a/src/components/detail-content/index.tsx
+++ b/src/components/detail-content/index.tsx
@@ -24,20 +24,17 @@ interface IDetail {
   tripodSkillCustom?: [];
 }
 
-interface IData<T> {
+interface IData {
   backSrc: string;
-  detail: T;
+  detail: IDetail;
 }
 
-interface IDetailContent<T> {
-  data: T;
+interface IDetailContent {
+  data: IData;
   children: ReactElement;
 }
 
-const DetailContent = ({
-  data,
-  children,
-}: PropsWithChildren<Partial<IDetailContent<IData<IDetail>>>>) => {
+const DetailContent = ({ data, children }: Partial<IDetailContent>) => {
   const { backSrc, detail } = data;
   const {
     src,

--- a/src/components/dialog/index.tsx
+++ b/src/components/dialog/index.tsx
@@ -1,9 +1,4 @@
-import React, {
-  PropsWithChildren,
-  ReactElement,
-  useCallback,
-  useEffect,
-} from "react";
+import React, { ReactElement, useCallback, useEffect } from "react";
 import * as Styled from "./index.style";
 
 interface IDialog {
@@ -11,7 +6,7 @@ interface IDialog {
   setDialog: (T: null) => void;
 }
 
-const Dialog = ({ dialog, setDialog }: PropsWithChildren<IDialog>) => {
+const Dialog = ({ dialog, setDialog }: IDialog) => {
   const handleCloseDialog = useCallback(() => {
     setDialog(null);
   }, [setDialog]);

--- a/src/components/double-list-container/index.tsx
+++ b/src/components/double-list-container/index.tsx
@@ -1,13 +1,11 @@
-import React, { PropsWithChildren, ReactElement, useMemo } from "react";
+import React, { ReactElement, useMemo } from "react";
 import { ListContainer } from "../";
 import * as Styled from "./index.style";
 
-interface IData {
-  divideType: string;
-}
-
-interface IDoubleListContainer<T> {
-  data?: T[];
+interface IDoubleListContainer {
+  data?: {
+    divideType: string;
+  }[];
   divideType?: string;
   lt?: null | string;
   rt?: null | string;
@@ -20,7 +18,7 @@ const DoubleListContainer = ({
   lt = null,
   rt = null,
   children,
-}: PropsWithChildren<IDoubleListContainer<IData>>) => {
+}: IDoubleListContainer) => {
   const [left, right] = useMemo(() => {
     return data.reduce(
       (prev, cur, i) => {

--- a/src/components/engrave/index.tsx
+++ b/src/components/engrave/index.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from "react";
+import React from "react";
 import { Image, Text, DangerousHTML } from "components/";
 import * as Styled from "./index.style";
 
@@ -6,7 +6,7 @@ interface EngraveProps {
   data?: any;
 }
 
-const Engrave = ({ data }: PropsWithChildren<EngraveProps>) => {
+const Engrave = ({ data }: EngraveProps) => {
   return (
     <Styled.Engrave className="engrave-item">
       <Image src={data.src} />

--- a/src/components/error-fallback/index.tsx
+++ b/src/components/error-fallback/index.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from "react";
+import React from "react";
 import { Text, Button, Image } from "components/";
 import * as Styled from "./index.style";
 
@@ -7,10 +7,7 @@ interface IErrorFallback {
   resetBoundary: () => void;
 }
 
-const ErrorFallback = ({
-  error,
-  resetBoundary,
-}: Partial<PropsWithChildren<IErrorFallback>>) => {
+const ErrorFallback = ({ error, resetBoundary }: Partial<IErrorFallback>) => {
   return (
     <Styled.ErrorFallback>
       <Styled.TextContainer data-testid="error-message">

--- a/src/components/event/index.tsx
+++ b/src/components/event/index.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, useCallback } from "react";
+import React, { useCallback } from "react";
 import { Image, Text } from "../";
 import * as Styled from "./index.style";
 
@@ -13,7 +13,7 @@ interface IEvent<T> {
   event?: T;
 }
 
-const Event = ({ event }: PropsWithChildren<IEvent<IData>>) => {
+const Event = ({ event }: IEvent<IData>) => {
   const { date, href, img, name } = event;
 
   const handleOpenEvent = useCallback(() => {

--- a/src/components/expedition/char/index.tsx
+++ b/src/components/expedition/char/index.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from "react";
+import React from "react";
 import { Button, Text } from "components/";
 import * as Styled from "./index.style";
 
@@ -11,7 +11,7 @@ interface IChar<T> {
   data?: T;
 }
 
-const Char = ({ data }: PropsWithChildren<IChar<IData>>) => (
+const Char = ({ data }: IChar<IData>) => (
   <Styled.Container>
     <Button aria-label="expedition-char">
       <Text type="desc" data-name={data.name}>

--- a/src/components/expedition/index.tsx
+++ b/src/components/expedition/index.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, ReactElement, useCallback } from "react";
+import React, { ReactElement, useCallback } from "react";
 import Server from "./server/index";
 import { Button, Text, MapContainer } from "components/";
 import * as Styled from "./index.style";
@@ -17,7 +17,7 @@ const UserExpedition = ({
   userData,
   setUserData,
   setDialog,
-}: PropsWithChildren<IUserExpedition<IUserData>>) => {
+}: IUserExpedition<IUserData>) => {
   const {
     expeditionInfo: { expeditionUserWrap },
   } = userData;

--- a/src/components/expedition/server/index.tsx
+++ b/src/components/expedition/server/index.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from "react";
+import React from "react";
 import Char from "../char/index";
 import * as Styled from "./index.style";
 import { Text, MapContainer } from "components/";
@@ -12,7 +12,7 @@ interface IServer<T> {
   data?: T;
 }
 
-const Server = ({ data }: PropsWithChildren<IServer<IData>>) => (
+const Server = ({ data }: IServer<IData>) => (
   <Styled.Server>
     <Styled.Title>
       <Text>{data.server}</Text>

--- a/src/components/image/index.tsx
+++ b/src/components/image/index.tsx
@@ -1,11 +1,11 @@
-import React, { ImgHTMLAttributes, PropsWithChildren } from "react";
+import React, { ImgHTMLAttributes } from "react";
 import * as Styled from "./index.style";
 
 interface Props extends ImgHTMLAttributes<HTMLImageElement> {
   color: string;
 }
 
-const Image = ({ color, ...props }: PropsWithChildren<Partial<Props>>) => {
+const Image = ({ color, ...props }: Partial<Props>) => {
   return (
     <div className="img-container">
       <Styled.Image color={color} {...props} />

--- a/src/components/indentstring/index.tsx
+++ b/src/components/indentstring/index.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from "react";
+import React from "react";
 import { DangerousHTML, MapContainer } from "../";
 import * as Styled from "./index.style";
 
@@ -11,7 +11,7 @@ interface IIndengString<T> {
   data?: T;
 }
 
-const IntentString = ({ data }: PropsWithChildren<IIndengString<IData>>) => {
+const IntentString = ({ data }: IIndengString<IData>) => {
   return (
     <Styled.Content>
       <DangerousHTML html={data.title} />

--- a/src/components/itempartbox/index.tsx
+++ b/src/components/itempartbox/index.tsx
@@ -1,17 +1,15 @@
-import React, { PropsWithChildren } from "react";
+import React from "react";
 import { DangerousHTML } from "../";
 import * as Styled from "./index.style";
 
-interface IData {
-  title: string;
-  desc: string;
+interface IItemPartBox {
+  data?: {
+    title: string;
+    desc: string;
+  };
 }
 
-interface IItemPartBox<T> {
-  data?: T;
-}
-
-const ItemPartBox = ({ data }: PropsWithChildren<IItemPartBox<IData>>) => {
+const ItemPartBox = ({ data }: IItemPartBox) => {
   return (
     <Styled.Content>
       <DangerousHTML html={data.title} />

--- a/src/components/list-container/index.tsx
+++ b/src/components/list-container/index.tsx
@@ -1,4 +1,4 @@
-import React, { cloneElement, PropsWithChildren, ReactElement } from "react";
+import React, { ReactElement } from "react";
 import { Text, MapContainer } from "components/";
 import * as Styled from "./index.style";
 
@@ -8,18 +8,14 @@ interface IListContainer {
   children: ReactElement;
 }
 
-const ListContainer = ({
-  title,
-  arr,
-  children,
-}: PropsWithChildren<IListContainer>) => {
+const ListContainer = ({ title, arr, children }: IListContainer) => {
   return (
     <>
       <Styled.Title>
         <Text>{title}</Text>
       </Styled.Title>
       <Styled.Content>
-        <MapContainer data={arr}>{cloneElement(children)}</MapContainer>
+        <MapContainer data={arr}>{children}</MapContainer>
       </Styled.Content>
     </>
   );

--- a/src/components/list-item/index.tsx
+++ b/src/components/list-item/index.tsx
@@ -1,9 +1,4 @@
-import React, {
-  cloneElement,
-  PropsWithChildren,
-  ReactElement,
-  useCallback,
-} from "react";
+import React, { cloneElement, ReactElement, useCallback } from "react";
 import { Image, Text, MapContainer } from "components/";
 import * as Styled from "./index.style";
 
@@ -15,23 +10,19 @@ interface IDetail {
   hover: boolean;
 }
 
-interface IData<T> {
+interface IData {
   backSrc?: string;
   type?: string;
-  detail: T;
+  detail: IDetail;
 }
 
-interface IListItem<T> {
+interface IListItem {
   children: ReactElement;
   setDialog: (T: ReactElement) => void;
-  data: T;
+  data: IData;
 }
 
-const ListItem = ({
-  data,
-  children,
-  setDialog,
-}: PropsWithChildren<Partial<IListItem<IData<IDetail>>>>) => {
+const ListItem = ({ data, children, setDialog }: Partial<IListItem>) => {
   const { backSrc, detail } = data;
 
   const setDialogHandler = useCallback(() => {

--- a/src/components/loading-spinner/index.tsx
+++ b/src/components/loading-spinner/index.tsx
@@ -1,9 +1,9 @@
-import React, { HTMLAttributes, PropsWithChildren } from "react";
+import React, { HTMLAttributes } from "react";
 import * as Styled from "./index.style";
 
 interface ILoadingSpinner extends HTMLAttributes<HTMLElement> {}
 
-const LoadingSpinner = ({ ...props }: PropsWithChildren<ILoadingSpinner>) => {
+const LoadingSpinner = ({ ...props }: ILoadingSpinner) => {
   return (
     <Styled.Content {...props}>
       <div></div>

--- a/src/components/map-container/index.tsx
+++ b/src/components/map-container/index.tsx
@@ -1,4 +1,4 @@
-import React, { cloneElement, PropsWithChildren, ReactElement } from "react";
+import React, { cloneElement, ReactElement } from "react";
 
 interface IMapContainer {
   data: any[];
@@ -10,7 +10,7 @@ const MapContainer = ({
   data = [],
   dataKey = "data",
   children,
-}: PropsWithChildren<IMapContainer>) => (
+}: IMapContainer) => (
   <>
     {data.map((data, i) =>
       cloneElement(children, { [dataKey]: data, key: i, i })

--- a/src/components/navigation/index.tsx
+++ b/src/components/navigation/index.tsx
@@ -1,9 +1,4 @@
-import React, {
-  PropsWithChildren,
-  ReactElement,
-  useCallback,
-  useMemo,
-} from "react";
+import React, { ReactElement, useCallback, useMemo } from "react";
 import { Button, Text, MapContainer } from "components/";
 import * as Styled from "./index.style";
 
@@ -20,11 +15,7 @@ interface INavigation {
   arr?: (string | ReactElement)[];
 }
 
-const Navigation = ({
-  arr,
-  selectedNav,
-  setNav,
-}: PropsWithChildren<INavigation>) => {
+const Navigation = ({ arr, selectedNav, setNav }: INavigation) => {
   return (
     <Styled.Container>
       <MapContainer data={arr} dataKey="navName">
@@ -34,12 +25,7 @@ const Navigation = ({
   );
 };
 
-export const Item = ({
-  navName,
-  setNav,
-  selectedSub,
-  i,
-}: PropsWithChildren<IItem>) => {
+export const Item = ({ navName, setNav, selectedSub, i }: IItem) => {
   const handleNavigation = useCallback(() => {
     setNav(i);
   }, [i, setNav]);

--- a/src/components/quality/index.tsx
+++ b/src/components/quality/index.tsx
@@ -1,16 +1,14 @@
-import React, { PropsWithChildren } from "react";
+import React from "react";
 import * as Styled from "./index.style";
 import { Text } from "components/";
 
-interface IData {
-  detail: { quality: number };
+interface IQuality {
+  data?: {
+    detail: { quality: number };
+  };
 }
 
-interface IQuality<T> {
-  data?: T;
-}
-
-const Quality = ({ data }: PropsWithChildren<IQuality<IData>>) => {
+const Quality = ({ data }: IQuality) => {
   const { quality } = data.detail;
 
   if (quality === -1) return null;

--- a/src/components/rune/index.tsx
+++ b/src/components/rune/index.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from "react";
+import React from "react";
 import { Image, Text } from "../";
 import * as Styled from "./index.style";
 
@@ -14,7 +14,7 @@ interface IRune {
   };
 }
 
-const Rune = ({ data }: PropsWithChildren<IRune>) => {
+const Rune = ({ data }: IRune) => {
   const rune = data.detail.rune;
 
   if (!rune) return null;

--- a/src/components/section-container/index.tsx
+++ b/src/components/section-container/index.tsx
@@ -1,9 +1,8 @@
-import React, { PropsWithChildren, ReactElement } from "react";
+import React, { PropsWithChildren } from "react";
 import * as Styled from "./index.style";
 import { Text } from "components/";
 
 interface ISectionContainer {
-  children: ReactElement;
   title: string;
 }
 

--- a/src/components/skill-container/index.tsx
+++ b/src/components/skill-container/index.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, ReactElement, useMemo } from "react";
+import React, { ReactElement, useMemo } from "react";
 import {
   DoubleListContainer,
   ListItem,
@@ -6,24 +6,18 @@ import {
   Rune,
 } from "components/";
 
-interface IUserData {
-  skillInfo: {
-    battleSkill;
-    lifeSkill;
+interface ISkillContainer {
+  userData: {
+    skillInfo: {
+      battleSkill;
+      lifeSkill;
+    };
   };
-}
-
-interface ISkillContainer<T> {
-  userData: T;
   subNav: number;
   setDialog(T: ReactElement): void;
 }
 
-const SkillContainer = ({
-  userData,
-  subNav,
-  setDialog,
-}: PropsWithChildren<ISkillContainer<IUserData>>) => {
+const SkillContainer = ({ userData, subNav, setDialog }: ISkillContainer) => {
   const { battleSkill = null, lifeSkill } = userData.skillInfo;
 
   const memoized = useMemo(() => {

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -1,8 +1,7 @@
-import React, { HTMLAttributes, PropsWithChildren, ReactNode } from "react";
+import React, { HTMLAttributes, PropsWithChildren } from "react";
 import * as Styled from "./index.style";
 
 export interface IText extends HTMLAttributes<HTMLDivElement> {
-  children: ReactNode;
   type: string;
   color: string;
 }

--- a/src/components/timer-container/index.tsx
+++ b/src/components/timer-container/index.tsx
@@ -1,9 +1,4 @@
-import React, {
-  PropsWithChildren,
-  useCallback,
-  useMemo,
-  useState,
-} from "react";
+import React, { useMemo, useState } from "react";
 import { Text, Timer, MapContainer } from "components/";
 import * as Styled from "./index.style";
 
@@ -17,7 +12,7 @@ const TimerContainer = ({
   data,
   rerenderKey,
   notification,
-}: PropsWithChildren<ITimerContainer>) => {
+}: ITimerContainer) => {
   const [, setTime] = useState(null);
 
   const date = new Date();

--- a/src/components/timer/index.tsx
+++ b/src/components/timer/index.tsx
@@ -1,36 +1,25 @@
-import React, {
-  PropsWithChildren,
-  useCallback,
-  useEffect,
-  useMemo,
-} from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
 import { useTimer } from "hooks/use-timer";
 import { useConditionalTimer } from "hooks/use-conditional-timer";
 import { Text, Image } from "components/";
 import { interval } from "utils/events/interval";
 import * as Styled from "./index.style";
 
-interface IData {
-  name: string;
-  src: string;
-  lv: string;
-  time: string;
-  endTime: string;
-  position: string;
-  endPosition: string;
-}
-
-interface ITimer<T> {
+interface ITimer {
   setTime: (T: string) => void;
-  data?: T;
+  data?: {
+    name: string;
+    src: string;
+    lv: string;
+    time: string;
+    endTime: string;
+    position: string;
+    endPosition: string;
+  };
   notification?;
 }
 
-const Timer = ({
-  setTime,
-  data,
-  notification,
-}: PropsWithChildren<ITimer<IData>>) => {
+const Timer = ({ setTime, data, notification }: ITimer) => {
   const { name, src, lv, time, endTime, position, endPosition } = data;
   const pos =
     typeof position !== "string" ? position[0] || endPosition : position;

--- a/src/components/tripodskillcustom/index.tsx
+++ b/src/components/tripodskillcustom/index.tsx
@@ -2,20 +2,16 @@ import React, { PropsWithChildren } from "react";
 import { DangerousHTML, Image } from "../";
 import * as Styled from "./index.style";
 
-interface IData {
-  name: null | string;
-  desc: null | string;
-  grade: null | string;
-  src: null | string;
+interface ITripodSkillCustom {
+  data?: {
+    name: null | string;
+    desc: null | string;
+    grade: null | string;
+    src: null | string;
+  };
 }
 
-interface ITripodSkillCustom<T> {
-  data?: T;
-}
-
-const TripodSkillCustom = ({
-  data,
-}: PropsWithChildren<ITripodSkillCustom<IData>>) => {
+const TripodSkillCustom = ({ data }: ITripodSkillCustom) => {
   const { name = null, desc = null, grade = null, src = null } = data;
 
   return (

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,10 +1,4 @@
-import React, {
-  PropsWithChildren,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   DAILY_ISLAND,
   FIELD_BOSS,
@@ -178,7 +172,7 @@ const Home = () => {
 const FetchCalendar = React.memo(function ({
   queryKey,
   isMidnight,
-}: PropsWithChildren<IFetchCalendar>) {
+}: IFetchCalendar) {
   const yoil = isMidnight.getDay();
   const calendarData = useCalendar(queryKey);
   const isWeek = 6 > yoil && yoil > 0;
@@ -201,9 +195,7 @@ const FetchCalendar = React.memo(function ({
   );
 });
 
-const FetchEvent = React.memo(function ({
-  queryKey,
-}: PropsWithChildren<IFetchEvent>) {
+const FetchEvent = React.memo(function ({ queryKey }: IFetchEvent) {
   const eventData = useEvent(queryKey);
 
   return (

--- a/src/pages/user-info/index.tsx
+++ b/src/pages/user-info/index.tsx
@@ -1,10 +1,4 @@
-import React, {
-  PropsWithChildren,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   BasicInfo,
   Expedition,
@@ -52,7 +46,7 @@ const UserInfo = ({
   match: {
     params: { name },
   },
-}: PropsWithChildren<IUserInfo>) => {
+}: IUserInfo) => {
   const [userKey, userCollectionKey] = useMemo(
     () => [
       ["userInfo", name],
@@ -73,7 +67,7 @@ const UserInfo = ({
 const FetchUserInfo = React.memo(function ({
   userKey,
   userCollectionKey,
-}: PropsWithChildren<IFetchUserInfo>) {
+}: IFetchUserInfo) {
   const history = useHistory();
   const { status, data: userData } = useUser(userKey);
   const nav = useNavigation();
@@ -182,7 +176,7 @@ const FetchUserCollection = React.memo(function ({
   queryKey,
   subNav,
   member,
-}: PropsWithChildren<IFetchUserCollection>) {
+}: IFetchUserCollection) {
   const userCollection = useUserCollection(queryKey, member);
 
   const memoized = useMemo(() => {


### PR DESCRIPTION
## 제너릭 타입 수정
1. children 속성을 사용하지 않거나, 확장이 필요한 경우, propswithchildren 제너릭 타입 제거
2. ReactNode 기반의 children 속성을 사용하는 경우만 위의 제너릭 타입 사용