### PR TITLE
불필요한 memo 제거

### DIFF
--- a/src/components/asyncBoundary/asyncBoundary.test.tsx
+++ b/src/components/asyncBoundary/asyncBoundary.test.tsx
@@ -29,7 +29,7 @@ const renderAsyncBoundary = (key: string, mock: Function) => {
   return (
     <AsyncBoundary
       errorFallback={ErrorFallback}
-      suspenseFallback={SuspenseFallback}
+      suspenseFallback={<SuspenseFallback />}
     >
       <Component />
     </AsyncBoundary>

--- a/src/components/dialogProvider/dialogProvider.tsx
+++ b/src/components/dialogProvider/dialogProvider.tsx
@@ -67,4 +67,4 @@ function Dialog({ children, rerender }: DialogProps) {
   );
 }
 
-export default React.memo(Dialog);
+export default Dialog;

--- a/src/components/sectionContainer/sectionContainer.tsx
+++ b/src/components/sectionContainer/sectionContainer.tsx
@@ -18,4 +18,4 @@ function SectionContainer({
   );
 }
 
-export default React.memo(SectionContainer);
+export default SectionContainer;

--- a/src/pages/home/home.tsx
+++ b/src/pages/home/home.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import {
   DAILY_ISLAND,
   FIELD_BOSS,

--- a/src/utils/test.tsx
+++ b/src/utils/test.tsx
@@ -31,7 +31,7 @@ const AllProviders = ({ children }: { children: ReactElement }) => {
   );
 };
 
-const customRender = (ui: ReactElement, options: any) =>
+const customRender = (ui: ReactElement, options?: any) =>
   render(ui, { wrapper: AllProviders, ...options });
 
 export * from "@testing-library/react";


### PR DESCRIPTION
## 불필요한 memo 제거
1. memo 특성상, 컴포넌트 조합을 통해 자동으로 생성되는 children props는 변화여부와 상관없이 항상 rerender되므로, memo가 작동되지 않아 불필요한 비용 발생
> 속성으로 전달할 때에는, ReactElement를 생성하는 함수로 전달되지만, 조합은 ReactElement자체를 생성하여 전달하기 때문이 아닐까 생각해봄
